### PR TITLE
Fix PDF URL field clearing

### DIFF
--- a/streamlit_rag_app_producao.py
+++ b/streamlit_rag_app_producao.py
@@ -699,14 +699,13 @@ def document_management_modal():
             
             if input_method == "🔗 URL do PDF":
                 # Lógica de limpeza de campos
-                url_value = ""
-                if st.session_state.get('clear_url_field', False):
+                if st.session_state.get("clear_url_field", False):
                     st.session_state.clear_url_field = False
-                    url_value = ""
-                
+                    st.session_state.pdf_url_input = ""
+
                 pdf_url = st.text_input(
                     "URL do documento PDF:",
-                    value=url_value,
+                    key="pdf_url_input",
                     placeholder="https://arxiv.org/pdf/2501.13956",
                     help="Cole aqui o link direto para o arquivo PDF"
                 )


### PR DESCRIPTION
## Summary
- use persistent `pdf_url_input` key for PDF URL input
- clear `st.session_state.pdf_url_input` when resetting field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9d56b44883318725e49080db932a